### PR TITLE
Add blueDarkAlt theme deprecation notice for v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.1.1 (September 1, 2021)
+
+### Added
+
+-   blueDarkAlt theme deprecation notice.
+
 ## v5.1.0 (March 30, 2021)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v5.1.1 (September 1, 2021)
+## v5.2.0 (September 1, 2021)
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/react-native-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "5.1.1-beta.0",
+    "version": "5.2.0",
     "description": "React Native themes for PX Blue applications",
     "main": "./dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/react-native-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "5.1.0",
+    "version": "5.1.1-beta.0",
     "description": "React Native themes for PX Blue applications",
     "main": "./dist/index.js",
     "scripts": {

--- a/src/blueDarkAltTheme.ts
+++ b/src/blueDarkAltTheme.ts
@@ -9,9 +9,11 @@ This code is licensed under the BSD-3 license found in the LICENSE file in the r
 import { blue, black, lightBlue } from '@pxblue/colors';
 import { blueDarkTheme } from './blueDarkTheme';
 
-  /**
-     * @deprecated in version 6.0.0
-     */
+console.warn('blueDarkAlt theme will be deprecated in v6.0.0, use blueDark theme');
+
+/** 
+ * @deprecated in v6.0.0 use blueDark theme
+ */
 export const blueDarkAltTheme = {
     ...blueDarkTheme,
     colors: {

--- a/src/blueDarkAltTheme.ts
+++ b/src/blueDarkAltTheme.ts
@@ -9,6 +9,9 @@ This code is licensed under the BSD-3 license found in the LICENSE file in the r
 import { blue, black, lightBlue } from '@pxblue/colors';
 import { blueDarkTheme } from './blueDarkTheme';
 
+  /**
+     * @deprecated in version 6.0.0
+     */
 export const blueDarkAltTheme = {
     ...blueDarkTheme,
     colors: {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-2453.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add blueDarkAlt theme deprecation notice for v6.0.0

#### Additional Context
- According to https://jsdoc.app/tags-deprecated.html, you can include some text that describes more about the deprecation, but I wasn't able to get that appearing in the IntelliSense popup.

This is what it looks like if you try to import the darkThemeAlt theme into a project.
![Screen Shot 2021-08-30 at 3 24 44 PM](https://user-images.githubusercontent.com/13989985/131394059-873ada24-6d8c-46be-b910-b3d02cc9a341.png)

